### PR TITLE
chore(examples): remove unused dependency "@everfund/example-css" fro…

### DIFF
--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -9,7 +9,6 @@
     "examples:start": "next"
   },
   "dependencies": {
-    "@everfund/example-css": "workspace:*",
     "@everfund/react-sdk": "workspace:*",
     "next": "13.4.12",
     "react": "18.2.0",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -9,7 +9,6 @@
     "examples:start": "vite"
   },
   "dependencies": {
-    "@everfund/example-css": "workspace:*",
     "@everfund/react-sdk": "workspace:*",
     "@types/react-dom": "^18.2.7",
     "react": "^18.2.0",

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -10,7 +10,6 @@
     "examples:start": "vite"
   },
   "dependencies": {
-    "@everfund/example-css": "workspace:*",
     "@everfund/js-sdk": "workspace:*"
   },
   "devDependencies": {

--- a/examples/vanilla-js/package.json
+++ b/examples/vanilla-js/package.json
@@ -9,7 +9,6 @@
     "examples:start": "vite"
   },
   "dependencies": {
-    "@everfund/example-css": "workspace:*",
     "@everfund/js-sdk": "workspace:*"
   },
   "devDependencies": {

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -9,7 +9,6 @@
     "examples:start": "vite"
   },
   "dependencies": {
-    "@everfund/example-css": "workspace:*",
     "@everfund/js-sdk": "workspace:*",
     "vue": "^3.3.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
 
   examples/next:
     dependencies:
-      '@everfund/example-css':
-        specifier: workspace:*
-        version: link:../../configs/example-css
       '@everfund/react-sdk':
         specifier: workspace:*
         version: link:../../packages/react-sdk
@@ -206,9 +203,6 @@ importers:
 
   examples/react:
     dependencies:
-      '@everfund/example-css':
-        specifier: workspace:*
-        version: link:../../configs/example-css
       '@everfund/react-sdk':
         specifier: workspace:*
         version: link:../../packages/react-sdk
@@ -234,9 +228,6 @@ importers:
 
   examples/svelte:
     dependencies:
-      '@everfund/example-css':
-        specifier: workspace:*
-        version: link:../../configs/example-css
       '@everfund/js-sdk':
         specifier: workspace:*
         version: link:../../packages/js-sdk
@@ -256,9 +247,6 @@ importers:
 
   examples/vanilla-js:
     dependencies:
-      '@everfund/example-css':
-        specifier: workspace:*
-        version: link:../../configs/example-css
       '@everfund/js-sdk':
         specifier: workspace:*
         version: link:../../packages/js-sdk
@@ -272,9 +260,6 @@ importers:
 
   examples/vue:
     dependencies:
-      '@everfund/example-css':
-        specifier: workspace:*
-        version: link:../../configs/example-css
       '@everfund/js-sdk':
         specifier: workspace:*
         version: link:../../packages/js-sdk


### PR DESCRIPTION
…m package.json files in examples

The "@everfund/example-css" dependency is no longer needed in the examples, so it has been removed from the package.json files in the "next", "react", "svelte", "vanilla-js", and "vue" directories. This change helps to clean up the dependencies and reduce unnecessary clutter in the examples.